### PR TITLE
Allow creating a Symbol attribte

### DIFF
--- a/lenscalc.py
+++ b/lenscalc.py
@@ -34,11 +34,8 @@ class Lens:
     def __getattribute__(self, name):
         attr = object.__getattribute__(self, name)
 
-        if isinstance(attr, Symbol):
-            try:
-                return self.parameters[name]
-            except KeyError:
-                raise AttributeError
+        if name in object.__getattribute__(self, "parameters"):
+            return self.parameters[name]
         else:
             return attr
 

--- a/test_special_calculations.py
+++ b/test_special_calculations.py
@@ -1,4 +1,5 @@
 from math import isclose
+from sympy.core.symbol import Symbol
 
 from lenscalc import Lens
 
@@ -39,3 +40,19 @@ def test_different_refractive_index():
     assert isclose(lens.NPS, 23.2854588912774)
 
     assert lens.NPS != 0
+
+
+def test_extra_symbol():
+    """
+    Test lens with an extra attribute of Symbol type.
+    """
+    lens = Lens()
+
+    extra = Symbol("extra")
+
+    # Set the arttribute.
+    lens.extra = extra
+    # Try to get the value of the attribute.
+    extra_attribute = lens.extra
+
+    assert extra_attribute == extra


### PR DESCRIPTION
I am not 100% sure about the test. On the previous version `extra_attribute = lens.extra` ends up with AttributeError, which is what it is supposed to do. The newer version doesn't raise the error, which is also good. What I am not sure about is, if the test makes sense.