### PR TITLE
All parameters of a lens are already in a dictionary

### DIFF
--- a/lenscalc_web/app.py
+++ b/lenscalc_web/app.py
@@ -48,6 +48,6 @@ def result(variables=None, values=None):
     except ValueError:
         return flask.render_template("index.html", variables=variables_info)
 
-    calculated_values = lens.__dict__["parameters"]
+    calculated_values = lens.parameters
 
     return flask.render_template("result.html", variables=variables_info, calculated=calculated_values)


### PR DESCRIPTION
There is no need to use `__dict__["parameters"]` because all variables are already in a dictionary.