### PR TITLE
Add tests for special calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ or `print(lens.BFL)` and similar to get them one by one.
         ```
     * If you don't want to run the tests with the combinations
     (there are a lot of them and they take a bit longer to run),
-    use this command:
+    use the following command (after the `ignore` switch, use the path
+    to the `test_variable_combinations.py` file).
+    Example for running the tests from the root of the repository.
         ```
-        $ python -m pytest --ignore=test_variable_combinations.py
+        $ python -m pytest --ignore=tests/test_variable_combinations.py
         ```
     * To run the tests with combinations faster, you can use the following
     command (you'll need to install extra requirements or only

--- a/lenscalc.py
+++ b/lenscalc.py
@@ -1,13 +1,15 @@
 from math import isclose  # Due to the floating point inaccuracy
+from decimal import Decimal
 
 from sympy import Eq
 from sympy.core.symbol import Symbol
-from sympy.core.numbers import Float
+from sympy.core.numbers import Float, Rational, Zero, Infinity
 from sympy.core.expr import Expr
 from sympy.solvers import solve
 
 
 class Lens:
+    numbers = int, float, Float, Rational, Decimal, Zero, Infinity  # Classes with numbers
     variables = "D1", "D2", "D", "n1", "nL", "n2", "r1", "r2", "CT", "P1", "P2", "f1", "f2", "EFL", "FFL", "BFL", "NPS"
 
     for variable in variables:
@@ -128,8 +130,7 @@ class Lens:
                 solved_equations[Symbol("NPS")] = Symbol("NPS")
             for variable in missing_values:
                 setattr(self, variable, solved_equations[Symbol(variable)].subs(self.replacements))
-            numbers = (int, float, Float)  # Classes with numbers
-            if isinstance(self.n1, numbers) and isinstance(self.n2, numbers) and isclose(self.n1, self.n2):
+            if isinstance(self.n1, Lens.numbers) and isinstance(self.n2, Lens.numbers) and isclose(self.n1, self.n2):
                 self.NPS = 0
             return
 

--- a/lenscalc.py
+++ b/lenscalc.py
@@ -32,6 +32,9 @@ class Lens:
     def __init__(self, *, D1=None, D2=None, D=None, n1=None, nL=None, n2=None, r1=None, r2=None, CT=None, P1=None, P2=None, f1=None, f2=None, EFL=None, FFL=None, BFL=None, NPS=None):
         self.parameters = locals()
         del self.parameters["self"]
+        for variable, value in self.parameters.items():
+            if isinstance(value, str):
+                setattr(self, variable, value)
 
     def __getattribute__(self, name):
         attr = object.__getattribute__(self, name)
@@ -44,6 +47,8 @@ class Lens:
     def __setattr__(self, name, value):
         try:
             if name in self.parameters:
+                if isinstance(value, str):
+                    value = float(value)
                 self.parameters[name] = value
                 return
         except AttributeError:

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -1,0 +1,34 @@
+from sympy.core.symbol import Symbol
+
+from lenscalc import Lens
+
+
+def test_extra_symbol():
+    """
+    Test lens with an extra attribute of Symbol type.
+    """
+    lens = Lens()
+
+    extra = Symbol("extra")
+
+    # Set the arttribute.
+    lens.extra = extra
+    # Try to get the value of the attribute.
+    extra_attribute = lens.extra
+
+    assert extra_attribute == extra
+
+
+def test_extra_string():
+    """
+    Test lens with extra attributes of string type.
+
+    The attributes should not be converted to type float.
+    """
+    lens = Lens()
+
+    lens.extra_string_text = "extra"
+    lens.extra_string_number = "1.5"
+
+    assert isinstance(lens.extra_string_text, str)
+    assert isinstance(lens.extra_string_number, str)

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -169,3 +169,63 @@ def test_lens_rational():
 
     assert compare_two_lenses(ORIGINAL_LENS, lens)
     assert isinstance(lens.f1, Rational)
+
+
+def test_variables_as_string():
+    """
+    Test a calculation where some variables are given as a string.
+
+    This is a thing that SymPy allows.
+    At the moment, the user isn't limited to do so.
+    When a variable is given as a string type, it is converted
+    to float type to prevent issues with the calculation.
+    """
+    lens = Lens(
+        D1="0.009994",
+        D2="0.0124925",
+        D="0.02223679991",
+        CT="3",
+        P1="1.12392500724714",
+        P2="-0.899140005797714"
+    )
+
+    lens.calculate()
+
+    assert compare_two_lenses(ORIGINAL_LENS, lens)
+
+
+def test_n1_as_string():
+    """
+    Test a calculation where n1 is given as a string.
+    """
+    lens = Lens(
+        n1="1.0003",
+        nL=1.5,
+        n2=1.0003,
+        r1=50,
+        r2=-40,
+        CT=3
+    )
+
+    lens.calculate()
+
+    assert compare_two_lenses(ORIGINAL_LENS, lens)
+
+
+def test_n1_as_string_added():
+    """
+    Test a calculation where n1 is given as a string later.
+    """
+    lens = Lens(
+        nL=1.5,
+        n2=1.0003,
+        r1=50,
+        r2=-40,
+        CT=3
+    )
+
+    lens.n1 = "1.0003"
+
+    lens.calculate()
+
+    assert compare_two_lenses(ORIGINAL_LENS, lens)

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 from sympy import oo  # infinity in SymPy
 from sympy.core.symbol import Symbol
+from sympy.core.numbers import Rational
 
 from lenscalc import Lens
 from test_variable_combinations import compare_two_lenses, ORIGINAL_LENS
@@ -147,3 +148,24 @@ def test_lens_decimal_output():
     lens.calculate()
 
     assert isinstance(lens.f1, Decimal)
+
+
+def test_lens_rational():
+    """
+    Test lens with input of type Rational.
+
+    The calculations should be exact, but the result has a weird form.
+    """
+    lens = Lens(
+        n1=Rational("1.0003"),
+        nL=Rational("1.5"),
+        n2=Rational("1.0003"),
+        r1=Rational("50"),
+        r2=Rational("-40"),
+        CT=Rational("3")
+    )
+
+    lens.calculate()
+
+    assert compare_two_lenses(ORIGINAL_LENS, lens)
+    assert isinstance(lens.f1, Rational)

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -1,8 +1,10 @@
 from math import isclose
 
+from sympy import oo  # infinity in SymPy
 from sympy.core.symbol import Symbol
 
 from lenscalc import Lens
+from test_variable_combinations import compare_two_lenses
 
 
 def test_different_refractive_index():
@@ -58,3 +60,42 @@ def test_extra_symbol():
     extra_attribute = lens.extra
 
     assert extra_attribute == extra
+
+
+def test_planar_surface_lens():
+    """
+    Test a lens with one surface as infinity.
+    """
+    lens = Lens(
+        n1=1.0003,
+        nL=1.5,
+        n2=1.0003,
+        r1=oo,
+        r2=-40,
+        CT=3
+    )
+
+    lens.calculate()
+
+    # This lens was compared to the result from the original calculator.
+    comparison_lens = Lens(
+        D1=0,
+        D2=0.0124925000000000,
+        D=0.0124925000000000,
+        n1=1.0003,
+        nL=1.5,
+        n2=1.0003,
+        r1=oo,
+        r2=-40,
+        CT=3,
+        P1=2.00060000000000,
+        P2=0,
+        f1=-80.0720432259355,
+        f2=80.0720432259355,
+        EFL=80.0480288172904,
+        FFL=-78.0714432259355,
+        BFL=80.0720432259355,
+        NPS=0
+    )
+
+    assert compare_two_lenses(comparison_lens, lens)

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 import pytest
 from sympy import oo  # infinity in SymPy
-from sympy.core.symbol import Symbol
 from sympy.core.numbers import Rational
 
 from lenscalc import Lens
@@ -49,37 +48,6 @@ def test_different_refractive_index():
 
     assert compare_two_lenses(comparison_lens, lens)
     assert lens.NPS != 0
-
-
-def test_extra_symbol():
-    """
-    Test lens with an extra attribute of Symbol type.
-    """
-    lens = Lens()
-
-    extra = Symbol("extra")
-
-    # Set the arttribute.
-    lens.extra = extra
-    # Try to get the value of the attribute.
-    extra_attribute = lens.extra
-
-    assert extra_attribute == extra
-
-
-def test_extra_string():
-    """
-    Test lens with extra attributes of string type.
-
-    The attributes should not be converted to type float.
-    """
-    lens = Lens()
-
-    lens.extra_string_text = "extra"
-    lens.extra_string_number = "1.5"
-
-    assert isinstance(lens.extra_string_text, str)
-    assert isinstance(lens.extra_string_number, str)
 
 
 def test_planar_surface_lens():

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -28,24 +28,27 @@ def test_different_refractive_index():
     lens.calculate()
 
     # This lens was compared to the result from the original calculator.
-    assert isclose(lens.D1, 0.00999400000000000)
-    assert isclose(lens.D2, 0.00425000000000000)
-    assert isclose(lens.D, 0.0141590510000000)
-    assert isclose(lens.n1, 1.0003)
-    assert isclose(lens.nL, 1.5)
-    assert isclose(lens.n2, 1.33)
-    assert isclose(lens.r1, 50)
-    assert isclose(lens.r2, -40)
-    assert isclose(lens.CT, 3)
-    assert isclose(lens.P1, 0.600502816184503)
-    assert isclose(lens.P2, -1.87752978642425)
-    assert isclose(lens.f1, -70.6473901393533)
-    assert isclose(lens.f2, 93.9328490306307)
-    assert isclose(lens.EFL, 70.6262022786697)
-    assert isclose(lens.FFL, -70.0468873231688)
-    assert isclose(lens.BFL, 92.0553192442064)
-    assert isclose(lens.NPS, 23.2854588912774)
+    comparison_lens = Lens(
+        D1=0.00999400000000000,
+        D2=0.00425000000000000,
+        D=0.0141590510000000,
+        n1=1.0003,
+        nL=1.5,
+        n2=1.33,
+        r1=50,
+        r2=-40,
+        CT=3,
+        P1=0.600502816184503,
+        P2=-1.87752978642425,
+        f1=-70.6473901393533,
+        f2=93.9328490306307,
+        EFL=70.6262022786697,
+        FFL=-70.0468873231688,
+        BFL=92.0553192442064,
+        NPS=23.2854588912774
+    )
 
+    assert compare_two_lenses(comparison_lens, lens)
     assert lens.NPS != 0
 
 

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -1,4 +1,3 @@
-from math import isclose
 from decimal import Decimal
 
 import pytest
@@ -66,6 +65,21 @@ def test_extra_symbol():
     extra_attribute = lens.extra
 
     assert extra_attribute == extra
+
+
+def test_extra_string():
+    """
+    Test lens with extra attributes of string type.
+
+    The attributes should not be converted to type float.
+    """
+    lens = Lens()
+
+    lens.extra_string_text = "extra"
+    lens.extra_string_number = "1.5"
+
+    assert isinstance(lens.extra_string_text, str)
+    assert isinstance(lens.extra_string_number, str)
 
 
 def test_planar_surface_lens():

--- a/tests/test_special_calculations.py
+++ b/tests/test_special_calculations.py
@@ -1,10 +1,12 @@
 from math import isclose
+from decimal import Decimal
 
+import pytest
 from sympy import oo  # infinity in SymPy
 from sympy.core.symbol import Symbol
 
 from lenscalc import Lens
-from test_variable_combinations import compare_two_lenses
+from test_variable_combinations import compare_two_lenses, ORIGINAL_LENS
 
 
 def test_different_refractive_index():
@@ -99,3 +101,49 @@ def test_planar_surface_lens():
     )
 
     assert compare_two_lenses(comparison_lens, lens)
+
+
+def test_lens_decimal_input():
+    """
+    Test lens with input of type Decimal.
+
+    Only checking whether the result is correct.
+    """
+    lens = Lens(
+        n1=Decimal("1.0003"),
+        nL=Decimal("1.5"),
+        n2=Decimal("1.0003"),
+        r1=Decimal("50"),
+        r2=Decimal("-40"),
+        CT=Decimal("3")
+    )
+
+    lens.calculate()
+
+    assert compare_two_lenses(ORIGINAL_LENS, lens)
+
+
+@pytest.mark.skip("https://github.com/sympy/sympy/issues/17648")
+def test_lens_decimal_output():
+    """
+    Test lens with input of type Decimal.
+
+    Only checking whether the result is in Decimal type.
+    Correct result is checked in the previous test.
+    At the moment skipped, because `sympy.solve` doesn't return the
+    result in Decimal type.
+    Once the issue is solved, this test will be merged with
+    the previous one.
+    """
+    lens = Lens(
+        n1=Decimal("1.0003"),
+        nL=Decimal("1.5"),
+        n2=Decimal("1.0003"),
+        r1=Decimal("50"),
+        r2=Decimal("-40"),
+        CT=Decimal("3")
+    )
+
+    lens.calculate()
+
+    assert isinstance(lens.f1, Decimal)

--- a/tests/test_variable_combinations.py
+++ b/tests/test_variable_combinations.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 from sympy.core.expr import Expr
-from sympy.core.numbers import Float, Zero, Infinity
+from sympy.core.numbers import Float, Rational, Zero, Infinity
 
 from lenscalc import Lens
 from combinations_for_tests import combinations_passing, combinations_failing
@@ -38,7 +38,7 @@ def compare_two_lenses(lens1, lens2):
     Return False if they aren't close enough and print the differences.
     """
     same = True
-    numbers = (int, float, Float, Decimal, Zero, Infinity)  # Classes with numbers
+    numbers = (int, float, Float, Rational, Decimal, Zero, Infinity)  # Classes with numbers
     for variable in Lens.variables:
         value_lens1 = getattr(lens1, variable)
         value_lens2 = getattr(lens2, variable)

--- a/tests/test_variable_combinations.py
+++ b/tests/test_variable_combinations.py
@@ -1,4 +1,5 @@
 from math import isclose
+from decimal import Decimal
 
 import pytest
 from sympy.core.expr import Expr
@@ -37,7 +38,7 @@ def compare_two_lenses(lens1, lens2):
     Return False if they aren't close enough and print the differences.
     """
     same = True
-    numbers = (int, float, Float, Zero, Infinity)  # Classes with numbers
+    numbers = (int, float, Float, Decimal, Zero, Infinity)  # Classes with numbers
     for variable in Lens.variables:
         value_lens1 = getattr(lens1, variable)
         value_lens2 = getattr(lens2, variable)

--- a/tests/test_variable_combinations.py
+++ b/tests/test_variable_combinations.py
@@ -2,7 +2,7 @@ from math import isclose
 
 import pytest
 from sympy.core.expr import Expr
-from sympy.core.numbers import Float, Zero
+from sympy.core.numbers import Float, Zero, Infinity
 
 from lenscalc import Lens
 from combinations_for_tests import combinations_passing, combinations_failing
@@ -37,7 +37,7 @@ def compare_two_lenses(lens1, lens2):
     Return False if they aren't close enough and print the differences.
     """
     same = True
-    numbers = (int, float, Float, Zero)  # Classes with numbers
+    numbers = (int, float, Float, Zero, Infinity)  # Classes with numbers
     for variable in Lens.variables:
         value_lens1 = getattr(lens1, variable)
         value_lens2 = getattr(lens2, variable)

--- a/tests/test_variable_combinations.py
+++ b/tests/test_variable_combinations.py
@@ -1,9 +1,7 @@
 from math import isclose
-from decimal import Decimal
 
 import pytest
 from sympy.core.expr import Expr
-from sympy.core.numbers import Float, Rational, Zero, Infinity
 
 from lenscalc import Lens
 from combinations_for_tests import combinations_passing, combinations_failing
@@ -38,11 +36,10 @@ def compare_two_lenses(lens1, lens2):
     Return False if they aren't close enough and print the differences.
     """
     same = True
-    numbers = (int, float, Float, Rational, Decimal, Zero, Infinity)  # Classes with numbers
     for variable in Lens.variables:
         value_lens1 = getattr(lens1, variable)
         value_lens2 = getattr(lens2, variable)
-        if isinstance(value_lens1, numbers) and isinstance(value_lens2, numbers):
+        if isinstance(value_lens1, Lens.numbers) and isinstance(value_lens2, Lens.numbers):
             if not isclose(value_lens1, value_lens2):
                 same = False
                 print(f"{variable}: {value_lens1}, {value_lens2}")


### PR DESCRIPTION
One test adds a lens with one surface as an infinity.

The other two are testing a lens with one or more variables given as a string. That is a thing that SymPy allows. One of the tests "breaks" `compare_two_lenses`, the other one just tests that an error occurs. I still need to decide how to fix the tests or if it is be better to disallow it.

Another idea that arose while writing the tests was if `compare_two_lenses` shouldn't be somewhere else. (A different file, and what else would make sense to move elsewhere.)